### PR TITLE
Fix #1: Migrated to Alpine, implemented server_default cmd

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,10 @@
-#!/bin/bash
+#!/bin/sh
+set -e
 
-lares "$@"
+if [[ $1 == "server_default" ]]
+then
+	/usr/local/bin/lares server --host $LARES_HOST --port $LARES_PORT --username $LARES_USERNAME --password $LARES_PASSWORD --interval $LARES_INTERVAL
+else
+	/usr/local/bin/lares "$@"
+fi
+


### PR DESCRIPTION
This PR contains two changes:

- Migrated the build stage as well as the final container to Alpine
- Implemented `server_default` as default `CMD` that is being executed through the `entrypoint.sh` by using the values defined in the `ENV` entries. Those values can be overridden using the `--env` argument of `docker run`. Also it allows for a nicer deployment on Kubernetes by using a ConfigMap resource for specifying those values.

This PR also fixes #1 by setting the default host to `0.0.0.0`.